### PR TITLE
Add basic SSR support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,9 @@ export default class ImageRenderer extends React.Component<
   }
 
   componentWillMount() {
+    if (typeof window === 'undefined') {
+      return;
+    }
     this.setState(loading(new Image()));
   }
 

--- a/src/server-side.test.js
+++ b/src/server-side.test.js
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment node
+ */
+// @flow
+import React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import ImageRender from '../src';
+
+describe('Server side rendering', () => {
+  it('should not fail when rendered in SSR', () => {
+    expect(() =>
+      ReactDOMServer.renderToString(
+        <ImageRender src="https://example.com/example.jpg" />
+      )
+    ).not.toThrowError();
+  });
+});


### PR DESCRIPTION
Hello :)

We are trying to use server side rendering for some of our component that are using react-render-image, but it currently fail on **componentWillMount** since ``Image`` is not defined in Node env.

Added a simple condition + test to ensure that works. Let me know what do you think!