### PR TITLE
Added support for srcset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2.1.0
+
+- Added support for `srcSet` and `sizes`
+
 ## 2.0.0
 
 - Switch from Flowtype to Typescript which changes how the library is bundled and means we're no longer providing typings for Flowtype
@@ -7,8 +11,8 @@
 
 ## 1.1.3
 
-* fix SSR support ([#1](https://github.com/jameslnewell/react-render-image/pull/1))
+- fix SSR support ([#1](https://github.com/jameslnewell/react-render-image/pull/1))
 
 ## 1.1.2
 
-* improved perf by removing cascading updates
+- improved perf by removing cascading updates

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,18 +1,22 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import React from 'react';
-import Image from '../src';
+import Image, {ImageRendererProps} from '../src';
 
 const defaultURL = 'https://i.pinimg.com/originals/2e/90/0a/2e900a74a9c7e7babe3343fa9dfd6a06.jpg';
 
 const App: React.FC = () => {
-  const input = React.useRef<HTMLInputElement>(null);
-  const [url, setURL] = React.useState(defaultURL);
+  const srcInput = React.useRef<HTMLInputElement>(null);
+  const srcsetInput = React.useRef<HTMLInputElement>(null);
+  const sizesInput = React.useRef<HTMLInputElement>(null);
+  const [props, setProps] = React.useState<Pick<ImageRendererProps, 'src' | 'srcset' | 'sizes'>>({src: defaultURL});
 
   const handleSubmit = (event: React.FormEvent): void => {
     event.preventDefault();
-    if (input.current){
-      setURL(input.current.value);
-    }
+    setProps({
+      src: srcInput.current?.value || '',
+      srcset: srcsetInput.current?.value,
+      sizes: sizesInput.current?.value,
+    });
   };
 
   return (
@@ -21,18 +25,39 @@ const App: React.FC = () => {
 
       <br />
       <form onSubmit={handleSubmit}>
-        <input
-          ref={input}
-          autoFocus
-          defaultValue={defaultURL}
-          style={{width: '340px'}}
-        />
-        <button>load..</button>
-        <Image src={url} loading="🔄" loaded="✅" errored="❌" />
+        <div>
+          <label htmlFor="src">src</label>
+          <input
+            id="src"
+            ref={srcInput}
+            autoFocus
+            defaultValue={defaultURL}
+            style={{width: '340px'}}
+          />
+        </div>
+        <div>
+          <label htmlFor="srcset">srcset</label>
+          <input
+            id="srcset"
+            ref={srcsetInput}
+            style={{width: '340px'}}
+          />
+        </div>
+        <div>
+          <label htmlFor="sizes">sizes</label>
+          <input
+            id="sizes"
+            ref={sizesInput}
+            autoFocus
+            style={{width: '340px'}}
+          />
+        </div>
+        <button>load...</button>
+        <Image {...props} loading="🔄" loaded="✅" errored="❌" />
       </form>
       <br />
 
-      <Image src={url}>
+      <Image {...props}>
         {({image, loaded, errored}) => {
           return (
             <div>
@@ -46,7 +71,7 @@ const App: React.FC = () => {
               {image && `Height: ${image.height}`}
               <br />
 
-              {loaded && <img src={url} alt="" style={{maxWidth: '100%'}} />}
+              {loaded && <img src={image?.currentSrc} alt="" style={{maxWidth: '100%'}} />}
             </div>
           );
         }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-render-image",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Render an image in React.",
   "keywords": [
     "react",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,19 @@ import * as React from 'react';
 
 export interface ImageRendererProps {
   src: string;
+  srcset?: HTMLImageElement['srcset'];
+  sizes?: HTMLImageElement['sizes'];
+
   loading?: React.ReactNode;
   loaded?: React.ReactNode;
   errored?: React.ReactNode;
+
   children?: (status: {
     image?: HTMLImageElement;
     loaded: boolean;
     errored: boolean;
   }) => React.ReactNode;
+
   onLoad?: () => void;
   onError?: () => void;
 }
@@ -30,6 +35,8 @@ const isErrored = (status: ImageRendererStatus): boolean =>
 
 const ImageRenderer: React.FC<ImageRendererProps> = ({
   src,
+  srcset,
+  sizes,
   onLoad,
   onError,
   loading: loadingView,
@@ -63,6 +70,8 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
           setStatus(ImageRendererStatus.ERRORED);
         };
 
+        image.current.sizes = sizes || '';
+        image.current.srcset = srcset || '';
         image.current.src = src;
       }
     }
@@ -71,7 +80,7 @@ const ImageRenderer: React.FC<ImageRendererProps> = ({
       unload();
       setStatus(ImageRendererStatus.LOADING);
     };
-  }, [src]);
+  }, [src, srcset, sizes]);
 
   React.useEffect(() => {
     if (isLoaded(status) && onLoad) {


### PR DESCRIPTION
Added support for `srcset` and `sizes` which allows the browser to load the most appropriately sized image

<img width="618" alt="Screen Shot 2020-07-09 at 9 41 02 am" src="https://user-images.githubusercontent.com/2237996/86980854-501e3b80-c1c8-11ea-9ca3-e90ed13ec130.png">
